### PR TITLE
Add srcset support

### DIFF
--- a/strapi-upload-adapter.js
+++ b/strapi-upload-adapter.js
@@ -133,8 +133,16 @@ class Adapter {
             : genericErrorText,
         )
       }
+      
+      const sizes = {}
+      Object.values(response[0].formats || []).forEach((format) => {
+        sizes[format.width.toString()] = format.url
+      })
 
-      resolve(response[0].url ? { default: response[0].url } : null)
+      resolve(response[0].url ? {
+        default: response[0].url,
+        ...sizes,
+      } : null)
     })
 
     // Upload progress when it is supported.


### PR DESCRIPTION
See https://github.com/ckeditor/ckeditor5-upload/blob/96fd9ee2d13a624013d9fa2f0a68689079b8e583/src/filerepository.js#L599

This will produce a responsive image with srcset correctly set and sizes="100vw" (CKEditor5 supports this size only).